### PR TITLE
Fix: Make light mode the default theme instead of system

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,8 +53,7 @@ export default function RootLayout({
       <body className="font-poppins">
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="light"
           disableTransitionOnChange
         >
           <a


### PR DESCRIPTION
We noticed that users - even those who have a dark theme on their browser/entire device, prefer light mode over dark mode for this website, which is the reason we decided to make this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated default theme behavior: the app now defaults to light mode instead of automatically detecting your system's theme preference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->