### PR TITLE
Fix: Remove placeholder text overlays from media images

### DIFF
--- a/app/media/page.tsx
+++ b/app/media/page.tsx
@@ -297,12 +297,6 @@ export default function MediaPage() {
                         className="object-cover"
                         sizes="(max-width: 1024px) 100vw, 50vw"
                       />
-                      {/* Placeholder overlay - remove when images are added */}
-                      <div className="absolute inset-0 bg-linear-to-br from-primary/5 to-secondary/5 flex items-center justify-center">
-                        <p className="text-xs text-foreground/40 text-center px-4">
-                          {event.image.alt}
-                        </p>
-                      </div>
                     </div>
                   </div>
                 </motion.article>
@@ -383,12 +377,6 @@ export default function MediaPage() {
                         className="object-cover"
                         sizes="(max-width: 1024px) 100vw, 50vw"
                       />
-                      {/* Placeholder overlay - remove when images are added */}
-                      <div className="absolute inset-0 bg-linear-to-br from-primary/5 to-secondary/5 flex items-center justify-center">
-                        <p className="text-xs text-foreground/40 text-center px-4">
-                          {event.image.alt}
-                        </p>
-                      </div>
                     </div>
                   </div>
                 </motion.article>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up image display on the Media page by removing overlay elements for a simpler, cleaner visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->