### PR TITLE
chore: use portless for stable local dev URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 // some next config
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ['TIC-new-website.localhost', '*.TIC-new-website.localhost'],
+  allowedDevOrigins: ['TICnewwebsite.localhost', '*.TICnewwebsite.localhost'],
   experimental: {
     optimizePackageImports: ["react-icons"],
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 // some next config
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ['TIC-new-website.localhost', '*.TIC-new-website.localhost'],
   experimental: {
     optimizePackageImports: ["react-icons"],
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "portless TIC-new-website next dev",
+    "dev": "portless TICnewwebsite next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "portless TIC-new-website next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"
@@ -30,6 +30,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "portless": "^0.15.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      portless:
+        specifier: ^0.15.4
+        version: 0.15.4
 
 packages:
 
@@ -1697,6 +1700,12 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  portless@0.15.4:
+    resolution: {integrity: sha512-tOxEsdlDGuPHO6DPkuK3c3mMV5ctXEgVFm53Sa8nfZ2RsRGTq4By424C6z5+JWfNbd3ktR5SOd1FJBOlB1Woqg==}
+    engines: {node: '>=24'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -3768,6 +3777,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  portless@0.15.4: {}
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11


### PR DESCRIPTION
## Summary
- Install `portless` as a devDependency
- Change `dev` to `portless TIC-new-website next dev` → `https://TIC-new-website.localhost`
- Add Next.js `allowedDevOrigins` for the portless host

## Test plan
- [ ] `pnpm install`
- [ ] `pnpm dev`
- [ ] Open `https://TIC-new-website.localhost` (run `pnpm exec portless trust` once if CA not trusted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Developer Experience**
  * Updated local development startup to use a consistent, named local address.
  * Added support for accessing the development site through the named local domain and its subdomains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->